### PR TITLE
Enhance SPOD plotting and re-use FFT blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,15 @@ pytest
 ### Parallel Execution
 
 Set the environment variable `OMP_NUM_THREADS` to control how many worker threads
-are used for FFT and SPOD computations. The default is `1`.
+are used for FFT and SPOD computations. The default is `1`. To maximize
+performance you can set it to the number of available CPU cores:
+
+```bash
+# Linux
+export OMP_NUM_THREADS=$(nproc)
+# macOS
+export OMP_NUM_THREADS=$(sysctl -n hw.ncpu)
+```
 
 ### Script Usage
 


### PR DESCRIPTION
## Summary
- add instructions on setting OMP_NUM_THREADS with auto-detection snippets
- save FFT blocks in SPOD results and re-use them in BSMD
- add cumulative energy plot to SPOD analysis
- show detected CPU threads when running SPOD or BSMD

## Testing
- `pytest -q`
- `python spod.py --help`
- `python bmsd.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684042de62fc832c928cbce05923efc7