### PR TITLE
Avoid FFT message for POD

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -473,7 +473,10 @@ class BaseAnalyzer:
         self.fs = 1 / self.data["dt"]
 
         print(f"Data loaded: {self.data['Ns']} snapshots, {self.data['Nx']}×{self.data['Ny']} spatial points")
-        print(f"FFT parameters: {self.nfft} points, {self.overlap * 100}% overlap, {self.nblocks} blocks")
+        if self.nfft > 1:
+            print(
+                f"FFT parameters: {self.nfft} points, {self.overlap * 100}% overlap, {self.nblocks} blocks"
+            )
 
     def compute_fft_blocks(self):
         """Compute blocked FFT using Welch's method."""


### PR DESCRIPTION
## Summary
- only print FFT parameters when `nfft` is greater than one

## Testing
- `python pod.py --prep`

------
https://chatgpt.com/codex/tasks/task_e_6840479b10f8832cbf1699db5176654d