### PR TITLE
Improve worker detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ pytest
 ### Parallel Execution
 
 Set the environment variable `OMP_NUM_THREADS` to control how many worker threads
-are used for FFT and SPOD computations. The default is `1`. To maximize
-performance you can set it to the number of available CPU cores:
+are used for FFT and SPOD computations. If the variable is unset or invalid,
+all detected CPU cores are used by default:
 
 ```bash
 # Linux

--- a/parallel_utils.py
+++ b/parallel_utils.py
@@ -3,14 +3,16 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 def get_num_workers():
-    """Return worker count from OMP_NUM_THREADS or cpu count."""
+    """Return worker count from ``OMP_NUM_THREADS`` or ``os.cpu_count()``."""
+    env = os.environ.get("OMP_NUM_THREADS")
     try:
-        env_val = int(os.environ.get("OMP_NUM_THREADS", "1"))
-    except ValueError:
-        env_val = 1
-    if env_val <= 0:
-        env_val = 1
-    return env_val
+        val = int(env) if env is not None else None
+    except (TypeError, ValueError):
+        val = None
+    if val is not None and val > 0:
+        return val
+    cpu = os.cpu_count() or 1
+    return cpu
 
 
 def parallel_map(func, iterable, workers=None):


### PR DESCRIPTION
## Summary
- update `get_num_workers` to use `os.cpu_count()` when `OMP_NUM_THREADS` is unset or invalid
- document default worker selection in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840479d9aec832c8f4bf7212f630df4