### PR TITLE
Add Accelerate and MKL FFT backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,19 @@ provided by conda-forge:
 conda install numpy scipy matplotlib
 ```
 
+To enable the optional `'accelerate'` FFT backend install the PyObjC bindings:
+
+```bash
+pip install pyobjc-framework-Accelerate
+```
+
 For Intel workstations with the Intel compiler stack you can take advantage of
 Intel's optimized libraries:
 
 ```bash
 conda install intel-openmp
 conda install numpy[mkl]
+conda install mkl_fft  # optional direct MKL backend
 ```
 
 ## Running Tests

--- a/configs.py
+++ b/configs.py
@@ -50,9 +50,14 @@ PREPROCESS_DIR_DMD = "./preprocess_dmd"
 FIG_DPI = 300
 FIG_FORMAT = "png"  # or "pdf"
 
-# FFT backend: "scipy", "numpy", "tensorflow", "torch", "cv2" (OpenCV)
-# Should match the naming used in fft_benchmark.py
-FFT_BACKEND = "scipy"  # Default, options: "scipy", "numpy", "tensorflow", "torch", "cv2"
+# FFT backend selection. Options include:
+#  - 'scipy', 'numpy'
+#  - 'tensorflow', 'torch'
+#  - 'mkl' for Intel MKL via :mod:`mkl_fft`
+#  - 'accelerate' for macOS vDSP/Accelerate
+#  - 'cv2' (OpenCV)
+# The name must match the keys defined in :mod:`fft.fft_backends`.
+FFT_BACKEND = "scipy"
 
 # Matplotlib/LaTeX options
 USE_LATEX = False  # Set True to enable LaTeX rendering

--- a/tests/test_fft_backends.py
+++ b/tests/test_fft_backends.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+import sys
+
+from fft import fft_backends
+
+
+def test_backend_registration():
+    backends = fft_backends.get_fft_backend_names()
+    assert 'numpy' in backends
+    assert 'scipy' in backends
+    assert 'accelerate' in backends
+    assert 'mkl' in backends
+
+
+def test_accelerate_unavailable():
+    func = fft_backends.get_fft_func('accelerate')
+    if sys.platform != 'darwin':
+        with pytest.raises(NotImplementedError):
+            func(np.ones(4))
+
+
+def test_mkl_unavailable():
+    try:
+        import mkl_fft  # noqa: F401
+    except Exception:
+        func = fft_backends.get_fft_func('mkl')
+        with pytest.raises(Exception):
+            func(np.ones(4))


### PR DESCRIPTION
## Summary
- add optional Accelerate FFT backend via vDSP
- add direct MKL backend using `mkl_fft`
- document new options in README and configs
- register new backends in fft_backends and provide tests

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae009690832c92a58ee4bfe11164