### PR TITLE
Fix plotting issues and cache errors

### DIFF
--- a/bmsd.py
+++ b/bmsd.py
@@ -35,6 +35,7 @@ from scipy.sparse import linalg as splinalg
 from tqdm import tqdm
 
 from configs import (
+    CMAP_SEQ,
     FIGURES_DIR_BSMD,
     RESULTS_DIR_BSMD,
     RESULTS_DIR_SPOD,


### PR DESCRIPTION
## Summary
- update BSMD imports
- allow multiple modes per figure and keep aspect ratio in DMD, POD, and SPOD plots
- generate traditional filenames when single mode per figure is requested
- handle HDF5 errors when reading cached SPOD FFT blocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68433a7fc410832c83b74c84621030f0