### PR TITLE
Align plot aspect ratios

### DIFF
--- a/bmsd.py
+++ b/bmsd.py
@@ -47,7 +47,7 @@ from utils import (
     BaseAnalyzer,
     auto_detect_weight_type,  # If used in __main__
     blocksfft,  # BSMD method description mentions qhat from Welch's method
-    get_aspect_ratio,
+    get_fig_aspect_ratio,
     get_num_threads,  # For detecting available CPU threads
     load_jetles_data,  # If used in __main__
     load_mat_data,  # If used in __main__
@@ -570,7 +570,7 @@ class BSMDAnalyzer(BaseAnalyzer):
         ny = self.data.get("Ny", int(np.sqrt(self.modes1.shape[1])))
         x_coords = self.data.get("x", np.arange(nx))
         y_coords = self.data.get("y", np.arange(ny))
-        aspect_ratio = get_aspect_ratio(self.data)
+        fig_aspect = get_fig_aspect_ratio(self.data)
         var_name = self.data.get("metadata", {}).get("var_name", "q")
         extent = (
             x_coords.min(),
@@ -583,13 +583,17 @@ class BSMDAnalyzer(BaseAnalyzer):
             mode1 = self.modes1[idx, :].real.reshape(nx, ny).T
             mode2 = self.modes2[idx, :].real.reshape(nx, ny).T
             triad = self.triads[idx]
-            fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+            fig, axes = plt.subplots(
+                1,
+                2,
+                figsize=(8 * fig_aspect, 4),
+            )
             im1 = axes[0].imshow(
                 mode1,
                 origin="lower",
                 extent=extent,
                 cmap=CMAP_SEQ,
-                aspect=aspect_ratio,
+                aspect="auto",
             )
             axes[0].set_title(f"Triad {tuple(triad)} Phi1 [{var_name}]")
             axes[0].set_xlabel("X")
@@ -601,7 +605,7 @@ class BSMDAnalyzer(BaseAnalyzer):
                 origin="lower",
                 extent=extent,
                 cmap=CMAP_SEQ,
-                aspect=aspect_ratio,
+                aspect="auto",
             )
             axes[1].set_title(f"Triad {tuple(triad)} Phi2 [{var_name}]")
             axes[1].set_xlabel("X")

--- a/dmd.py
+++ b/dmd.py
@@ -26,7 +26,7 @@ from configs import (
 from utils import (
     BaseAnalyzer,
     auto_detect_weight_type,
-    get_aspect_ratio,
+    get_fig_aspect_ratio,
     load_jetles_data,
     load_mat_data,
     make_result_filename,
@@ -150,14 +150,19 @@ class DMDAnalyzer(BaseAnalyzer):
         x_coords = self.data.get("x", np.arange(nx))
         y_coords = self.data.get("y", np.arange(ny))
         is_2d = self.modes.shape[0] == nx * ny and nx > 1 and ny > 1
-        aspect_ratio = get_aspect_ratio(self.data)
+        fig_aspect = get_fig_aspect_ratio(self.data)
         var_name = self.data.get("metadata", {}).get("var_name", "q")
 
         for start in range(0, n_modes, modes_per_fig):
             end = min(start + modes_per_fig, n_modes)
             ncols = end - start
             if is_2d:
-                fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols * aspect_ratio, 4), squeeze=False)
+                fig, axes = plt.subplots(
+                    1,
+                    ncols,
+                    figsize=(4 * ncols * fig_aspect, 4),
+                    squeeze=False,
+                )
             else:
                 fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols, 3), squeeze=False)
             axes = axes.ravel()
@@ -177,7 +182,7 @@ class DMDAnalyzer(BaseAnalyzer):
                         origin="lower",
                         extent=extent,
                         cmap=CMAP_DIV,
-                        aspect=aspect_ratio,
+                        aspect="auto",
                     )
                     fig.colorbar(im, ax=ax, label="Mode amplitude")
                     ax.set_xlabel("X")

--- a/pod.py
+++ b/pod.py
@@ -37,7 +37,7 @@ from parallel_utils import print_optimization_status
 from utils import (
     BaseAnalyzer,
     auto_detect_weight_type,
-    get_aspect_ratio,
+    get_fig_aspect_ratio,
     load_jetles_data,
     load_mat_data,
     make_result_filename,  # For saving results
@@ -354,7 +354,7 @@ class PODAnalyzer(BaseAnalyzer):
         x_coords = self.data.get("x", np.arange(Nx))
         y_coords = self.data.get("y", np.arange(Ny))
 
-        aspect_ratio = get_aspect_ratio(self.data)
+        fig_aspect = get_fig_aspect_ratio(self.data)
 
         # Determine if plotting 1D or 2D modes
         is_2d_plot = (self.modes.shape[0] == Nx * Ny) and (Nx > 1 and Ny > 1)
@@ -365,7 +365,12 @@ class PODAnalyzer(BaseAnalyzer):
             end = min(start + modes_per_fig, n_modes)
             ncols = end - start
             if is_2d_plot:
-                fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols * aspect_ratio, 4), squeeze=False)
+                fig, axes = plt.subplots(
+                    1,
+                    ncols,
+                    figsize=(4 * ncols * fig_aspect, 4),
+                    squeeze=False,
+                )
             else:
                 fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols, 3), squeeze=False)
             axes = axes.ravel()
@@ -383,7 +388,7 @@ class PODAnalyzer(BaseAnalyzer):
                     )
                     im = ax.imshow(
                         mode_reshaped.T,
-                        aspect=aspect_ratio,
+                        aspect="auto",
                         origin="lower",
                         extent=extent,
                         cmap=CMAP_SEQ,
@@ -569,13 +574,6 @@ class PODAnalyzer(BaseAnalyzer):
         x_coords = self.data.get("x", np.arange(Nx))
         y_coords = self.data.get("y", np.arange(Ny))
 
-        if x_coords.ndim == 1 and y_coords.ndim == 1:
-            dx = x_coords.max() - x_coords.min()
-            dy = y_coords.max() - y_coords.min()
-            aspect_ratio = dy / dx if dx > 0 and dy > 0 else "auto"
-        else:
-            aspect_ratio = "auto"
-
         num_snapshots_to_show = len(snapshot_indices_to_plot)
         num_recons_per_snapshot = len(modes_for_reconstruction)
 
@@ -591,7 +589,13 @@ class PODAnalyzer(BaseAnalyzer):
             if is_2d_plot:
                 img_data = original_snapshot.reshape(Nx, Ny).T
                 extent = [x_coords.min(), x_coords.max(), y_coords.min(), y_coords.max()] if x_coords.ndim == 1 and y_coords.ndim == 1 else None
-                im = ax.imshow(img_data, aspect=aspect_ratio, origin="lower", extent=extent, cmap=CMAP_DIV)
+                im = ax.imshow(
+                    img_data,
+                    aspect="auto",
+                    origin="lower",
+                    extent=extent,
+                    cmap=CMAP_DIV,
+                )
                 fig.colorbar(im, ax=ax, label="Amplitude")
                 ax.set_xlabel("X")
                 ax.set_ylabel("Y")
@@ -611,7 +615,13 @@ class PODAnalyzer(BaseAnalyzer):
 
                 if is_2d_plot:
                     img_data_recon = reconstructed_snapshot_k.reshape(Nx, Ny).T
-                    im = ax.imshow(img_data_recon, aspect=aspect_ratio, origin="lower", extent=extent, cmap=CMAP_DIV)
+                    im = ax.imshow(
+                        img_data_recon,
+                        aspect="auto",
+                        origin="lower",
+                        extent=extent,
+                        cmap=CMAP_DIV,
+                    )
                     fig.colorbar(im, ax=ax, label="Amplitude")
                     ax.set_xlabel("X")
                     ax.set_ylabel("Y")

--- a/spod.py
+++ b/spod.py
@@ -28,7 +28,7 @@ from parallel_utils import print_optimization_status
 from utils import (
     BaseAnalyzer,
     auto_detect_weight_type,  # For example in __main__ or if SPODAnalyzer needs it directly
-    get_aspect_ratio,
+    get_fig_aspect_ratio,
     get_num_threads,  # Utility to get number of available CPU threads
     load_jetles_data,  # For example in __main__
     load_mat_data,  # For example in __main__
@@ -558,7 +558,7 @@ class SPODAnalyzer(BaseAnalyzer):
         x_coords = self.data.get("x", np.arange(Nx))
         y_coords = self.data.get("y", np.arange(Ny))
 
-        aspect_ratio = get_aspect_ratio(self.data)
+        fig_aspect = get_fig_aspect_ratio(self.data)
         var_name = self.data.get("metadata", {}).get("var_name", "q")
 
         for f_idx in freq_indices:
@@ -567,7 +567,12 @@ class SPODAnalyzer(BaseAnalyzer):
                 end = min(start + modes_per_fig, n_modes)
                 ncols = end - start
                 if Nx * Ny == self.modes.shape[1] and Nx > 1 and Ny > 1:
-                    fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols * aspect_ratio, 4), squeeze=False)
+                    fig, axes = plt.subplots(
+                        1,
+                        ncols,
+                        figsize=(4 * ncols * fig_aspect, 4),
+                        squeeze=False,
+                    )
                 else:
                     fig, axes = plt.subplots(1, ncols, figsize=(4 * ncols, 3), squeeze=False)
                 axes = axes.ravel()
@@ -579,7 +584,7 @@ class SPODAnalyzer(BaseAnalyzer):
                     if Nx * Ny == mode_real.size and Nx > 1 and Ny > 1:
                         mode_2d = mode_real.reshape(Nx, Ny).T
                         im = ax.contourf(x_coords, y_coords, mode_2d, levels=60, cmap="bwr")
-                        ax.set_aspect(aspect_ratio)
+                        ax.set_aspect("auto")
                         fig.colorbar(im, ax=ax, shrink=0.8, label=r"Re($\Phi$)")
                         ax.set_xlabel("X")
                         ax.set_ylabel("Y")

--- a/utils.py
+++ b/utils.py
@@ -90,6 +90,17 @@ def get_aspect_ratio(data: dict) -> float | str:
     return compute_aspect_ratio(x, y)
 
 
+def get_fig_aspect_ratio(data: dict, clamp_low: float = 0.5, clamp_high: float = 2.0) -> float:
+    """Return ``Nx/Ny`` ratio clamped for figure sizing."""
+    nx = int(data.get("Nx", 1))
+    ny = int(data.get("Ny", 1))
+    if ny <= 0:
+        aspect = 1.0
+    else:
+        aspect = nx / ny
+    return max(clamp_low, min(aspect, clamp_high))
+
+
 def load_jetles_data(file_path):
     return di_load_jetles_data(file_path)
 


### PR DESCRIPTION
## Summary
- add `get_fig_aspect_ratio` utility
- use the new clamped aspect ratio when generating figures
- set image aspect to `auto` in analysis plots

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433d868b40832c9fea03538a1b39ae