### PR TITLE
Fix SPOD reconstruction error matrix shape

### DIFF
--- a/spod.py
+++ b/spod.py
@@ -701,13 +701,15 @@ class SPODAnalyzer(BaseAnalyzer):
         if n_modes_max is None:
             n_modes_max = n_modes_avail
         n_modes_max = min(n_modes_max, n_modes_avail)
-        W = np.diag(self.W.flatten()) if self.W.ndim == 1 else self.W
+        W = np.diagflat(self.W) if self.W.ndim == 1 or self.W.shape[1] == 1 else self.W
         norm_orig = np.linalg.norm(qhat_f, "fro")
         errors = []
         mode_counts = range(1, n_modes_max + 1)
         for k in mode_counts:
             phi_k = modes_f[:, :k]
             coeffs = phi_k.conj().T @ W @ qhat_f
+            if coeffs.shape != (k, qhat_f.shape[1]):
+                raise ValueError(f"Coefficient matrix has unexpected shape: {coeffs.shape}, expected ({k}, {qhat_f.shape[1]})")
             qrec = phi_k @ coeffs
             errors.append(np.linalg.norm(qhat_f - qrec, "fro") / norm_orig)
         fig, ax = plt.subplots()

--- a/tests/test_spod_plot.py
+++ b/tests/test_spod_plot.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from spod import SPODAnalyzer
@@ -60,3 +59,31 @@ def test_plot_modes_and_timecoeffs(tmp_path):
     analyzer.plot_time_coeffs()
     expected_time = tmp_path / f"dummy_SPOD_timecoeffs_St{st:.4f}_nfft4_noverlap0.0.png"
     assert expected_time.exists()
+
+
+def test_plot_reconstruction_error(tmp_path):
+    data = {
+        "q": np.random.randn(8, 4),
+        "x": np.linspace(0, 1, 2),
+        "y": np.linspace(0, 1, 2),
+        "dt": 1.0,
+        "Nx": 2,
+        "Ny": 2,
+        "Ns": 8,
+    }
+    analyzer = SPODAnalyzer(
+        file_path="dummy.h5",
+        nfft=4,
+        overlap=0.0,
+        results_dir=tmp_path,
+        figures_dir=tmp_path,
+        data_loader=lambda _: data,
+        spatial_weight_type="uniform",
+    )
+    analyzer.load_and_preprocess()
+    analyzer.compute_fft_blocks()
+    analyzer.perform_spod()
+    analyzer.plot_reconstruction_error()
+    st = analyzer.St[np.argmax(analyzer.eigenvalues[:, 0])]
+    expected = tmp_path / f"dummy_SPOD_reconstruction_error_St{st:.4f}_nfft4_noverlap0.0.png"
+    assert expected.exists()


### PR DESCRIPTION
## Summary
- ensure reconstruction error uses a proper diagonal weight matrix
- check coefficient matrix dimensions during reconstruction
- test plotting reconstruction error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e521f394832ca0aef56fa124e223