### PR TITLE
Report thread pools and clarify OMP usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ pytest
 ### Parallel Execution
 
 FFT and matrix operations rely on NumPy's multithreaded BLAS libraries.
-The number of threads is taken from the `OMP_NUM_THREADS` environment
-variable when present; otherwise all available CPU cores are used.
+Only the underlying BLAS/LAPACK routines honor the `OMP_NUM_THREADS`
+environment variable automatically. Other Python code typically runs
+single-threaded.
 
 Check which optimizations are active by running:
 
@@ -156,7 +157,7 @@ Intermediate FFT blocks (`qhat`) are stored in HDF5 files whose names are genera
 
 ### Threads and performance
 
-FFT computation uses the backend specified in `configs.py` and automatically leverages the multithreaded BLAS library shipped with NumPy. The helper `get_num_threads()` reports the number of threads (taken from `OMP_NUM_THREADS` when set).
+FFT computation uses the backend specified in `configs.py` and automatically leverages the multithreaded BLAS library shipped with NumPy. The helper `get_num_threads()` reports the number of threads requested via `OMP_NUM_THREADS`, but only BLAS/LAPACK operations use these threads by default.
 
 ### Extending the code
 

--- a/bmsd.py
+++ b/bmsd.py
@@ -698,8 +698,9 @@ if __name__ == "__main__":
     parser.add_argument("--plot", action="store_true", help="Generate example plots")
     args = parser.parse_args()
 
-    threads_available = get_num_threads()
-    print(f"Available CPU threads detected: {threads_available}")
+    from parallel_utils import get_threadpool_summary
+
+    print(f"Thread pools: {get_threadpool_summary()}")
 
     print_optimization_status()
 

--- a/parallel_utils.py
+++ b/parallel_utils.py
@@ -9,8 +9,10 @@ functions run on any standard Python installation.
 Author: Modal Decomposition Team
 """
 
-import numpy as np
 import multiprocessing
+
+import numpy as np
+from threadpoolctl import threadpool_info
 
 # OpenMP support was removed. All routines rely on NumPy vectorization and the
 # underlying BLAS implementation.
@@ -21,17 +23,17 @@ PARALLEL_AVAILABLE = True
 def calculate_polar_weights_optimized(x, y):
     """
     Calculate integration weights for 2D cylindrical grid.
-    
+
     This function uses a fully vectorized NumPy implementation that works on any
     platform without special dependencies.
-    
+
     Parameters:
     -----------
     x : np.ndarray
         Axial coordinates
-    y : np.ndarray  
+    y : np.ndarray
         Radial coordinates
-        
+
     Returns:
     --------
     np.ndarray
@@ -43,46 +45,46 @@ def calculate_polar_weights_optimized(x, y):
 def _calculate_weights_numpy(x, y):
     """Vectorized NumPy implementation of polar weights."""
     Nx, Ny = len(x), len(y)
-    
+
     # Calculate y-direction (r-direction) integration weights (Wy) - vectorized
     Wy = np.zeros(Ny)
-    
+
     if Ny > 1:
         # First point (centerline)
         y_mid_right = (y[0] + y[1]) / 2
         Wy[0] = np.pi * y_mid_right**2
-        
+
         # Middle points - vectorized
         if Ny > 2:
             y_mid_left = (y[:-2] + y[1:-1]) / 2
             y_mid_right = (y[1:-1] + y[2:]) / 2
             Wy[1:-1] = np.pi * (y_mid_right**2 - y_mid_left**2)
-        
+
         # Last point
         y_mid_left = (y[-2] + y[-1]) / 2
         Wy[-1] = np.pi * (y[-1] ** 2 - y_mid_left**2)
     else:
         Wy[0] = np.pi * y[0] ** 2
-    
+
     # Calculate x-direction integration weights (Wx) - vectorized
     Wx = np.zeros(Nx)
-    
+
     if Nx > 1:
         # First point
         Wx[0] = (x[1] - x[0]) / 2
-        
+
         # Middle points - vectorized
         if Nx > 2:
             Wx[1:-1] = (x[2:] - x[:-2]) / 2
-        
+
         # Last point
         Wx[-1] = (x[-1] - x[-2]) / 2
     else:
         Wx[0] = 1.0
-    
+
     # Combine weights using outer product (much faster than loops)
     W = np.outer(Wx, Wy).flatten()
-    
+
     return W.reshape(-1, 1)
 
 
@@ -92,14 +94,13 @@ def _calculate_weights_openmp(x, y):
     return _calculate_weights_numpy(x, y)
 
 
-def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=False, 
-                       window_norm="power", window_type="hamming"):
+def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=False, window_norm="power", window_type="hamming"):
     """
     Optimized blocked FFT computation.
-    
+
     This function uses the best available linear algebra backend (BLAS/LAPACK)
     and optimized memory access patterns for better performance.
-    
+
     Parameters:
     -----------
     q : np.ndarray
@@ -118,7 +119,7 @@ def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=
         Window normalization type ('amplitude' or 'power')
     window_type : str
         Window type ('hamming' or 'sine')
-    
+
     Returns:
     --------
     np.ndarray
@@ -126,7 +127,7 @@ def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=
     """
     # Import FFT backend
     from fft.fft_backends import get_fft_func
-    
+
     # Select window function
     if window_type == "sine":
         window = np.sin(np.pi * (np.arange(nfft) + 0.5) / nfft)
@@ -147,7 +148,7 @@ def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=
 
     # Process each block with optimized memory access
     fft_func = get_fft_func()
-    
+
     for iblk in range(nblocks):
         ts = min(iblk * (nfft - novlap), q.shape[0] - nfft)  # Start index
         tf = np.arange(ts, ts + nfft)  # Time indices for the block
@@ -168,7 +169,7 @@ def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=
 
         # Apply window and FFT
         windowed_block = block_centered * window_broadcast
-        
+
         # Compute full FFT (uses optimized BLAS/LAPACK routines)
         full_fft_result = fft_func(windowed_block, axis=0)
 
@@ -181,9 +182,9 @@ def blocksfft_optimized(q, nfft, nblocks, novlap, blockwise_mean=False, normvar=
 def spod_single_frequency_optimized(qhat, w, nblocks, dst, num_modes=None, return_psi=False):
     """
     Optimized single frequency SPOD computation.
-    
+
     Uses optimized BLAS/LAPACK routines for matrix operations.
-    
+
     Parameters:
     -----------
     qhat : np.ndarray
@@ -196,7 +197,7 @@ def spod_single_frequency_optimized(qhat, w, nblocks, dst, num_modes=None, retur
         Frequency resolution (delta f)
     num_modes : int, optional
         Number of modes to keep (default: all)
-        
+
     Returns:
     --------
     tuple
@@ -206,65 +207,65 @@ def spod_single_frequency_optimized(qhat, w, nblocks, dst, num_modes=None, retur
     """
     # Normalize FFT coefficients
     x = qhat / np.sqrt(nblocks * dst)
-    
+
     # Compute the weighted cross-spectral density (CSD) matrix M_f
     # This uses optimized BLAS routines
     xprime_w = np.conj(x).T * w.T  # X_f^H * W
     m = xprime_w @ x  # (X_f^H * W) * X_f = M_f
-    
+
     # Solve eigenvalue problem (uses optimized LAPACK)
     lambda_tilde, psi = np.linalg.eigh(m)
-    
+
     # Sort eigenvalues and eigenvectors in descending order
     idx = lambda_tilde.argsort()[::-1]
     lambda_tilde = lambda_tilde[idx]
     psi = psi[:, idx]
-    
+
     # Limit number of modes if specified
     if num_modes is not None:
         num_modes = min(num_modes, len(lambda_tilde))
         lambda_tilde = lambda_tilde[:num_modes]
         psi = psi[:, :num_modes]
-    
+
     # Compute spatial SPOD modes
     inv_sqrt_lambda = np.zeros_like(lambda_tilde)
     mask = lambda_tilde > 1e-12
     inv_sqrt_lambda[mask] = 1.0 / np.sqrt(lambda_tilde[mask])
-    
+
     # This uses optimized BLAS matrix multiplication
     phi = x @ (psi * inv_sqrt_lambda[np.newaxis, :])
-    
+
     if return_psi:
         return phi, np.abs(lambda_tilde), psi
     return phi, np.abs(lambda_tilde)
 
 
-def pod_computation_optimized(data_matrix, use_method='svd'):
+def pod_computation_optimized(data_matrix, use_method="svd"):
     """
     Optimized POD computation using high-performance linear algebra.
-    
+
     Parameters:
     -----------
     data_matrix : np.ndarray
         Data matrix [space, time]
     use_method : str
         Method to use ('svd' or 'covariance')
-        
+
     Returns:
     --------
     tuple
         (phi, sigma, temporal_coeffs)
         phi : Spatial POD modes [space, mode]
-        sigma : Singular values [mode]  
+        sigma : Singular values [mode]
         temporal_coeffs : Temporal coefficients [time, mode]
     """
     print("🚀 Using optimized POD computation...")
-    
+
     # Center the data
     data_mean = np.mean(data_matrix, axis=1, keepdims=True)
     data_centered = data_matrix - data_mean
-    
-    if use_method == 'svd':
+
+    if use_method == "svd":
         # Direct SVD - automatically uses optimized BLAS/LAPACK
         phi, sigma, vt = np.linalg.svd(data_centered, full_matrices=False)
         temporal_coeffs = vt.T * sigma
@@ -274,12 +275,12 @@ def pod_computation_optimized(data_matrix, use_method='svd'):
             # More time steps than spatial points - use spatial covariance
             cov_matrix = (data_centered @ data_centered.T) / (data_centered.shape[1] - 1)
             eigenvals, phi = np.linalg.eigh(cov_matrix)
-            
+
             # Sort in descending order
             idx = eigenvals.argsort()[::-1]
             eigenvals = eigenvals[idx]
             phi = phi[:, idx]
-            
+
             # Compute temporal coefficients
             sigma = np.sqrt(np.maximum(eigenvals, 0))
             temporal_coeffs = phi.T @ data_centered
@@ -287,12 +288,12 @@ def pod_computation_optimized(data_matrix, use_method='svd'):
             # More spatial points than time steps - use temporal covariance
             cov_matrix = (data_centered.T @ data_centered) / (data_centered.shape[1] - 1)
             eigenvals, temporal_modes = np.linalg.eigh(cov_matrix)
-            
+
             # Sort in descending order
             idx = eigenvals.argsort()[::-1]
             eigenvals = eigenvals[idx]
             temporal_modes = temporal_modes[:, idx]
-            
+
             # Compute spatial modes
             sigma = np.sqrt(np.maximum(eigenvals, 0))
             phi = data_centered @ temporal_modes
@@ -300,55 +301,62 @@ def pod_computation_optimized(data_matrix, use_method='svd'):
             for i in range(phi.shape[1]):
                 if sigma[i] > 1e-12:
                     phi[:, i] /= sigma[i]
-            
+
             temporal_coeffs = temporal_modes * sigma
-    
+
     return phi, sigma, temporal_coeffs
 
 
 def get_optimization_info():
     """Return information about available optimizations."""
-    info = {
-        'parallel_available': PARALLEL_AVAILABLE,
-        'cpu_count': multiprocessing.cpu_count(),
-        'numpy_blas': 'Unknown'
-    }
-    
+    info = {"parallel_available": PARALLEL_AVAILABLE, "cpu_count": multiprocessing.cpu_count(), "numpy_blas": "Unknown"}
+
     # Try to detect BLAS implementation
     try:
-        import numpy as np
-        from io import StringIO
         from contextlib import redirect_stdout
-        
+        from io import StringIO
+
+        import numpy as np
+
         # Capture config output instead of printing it
         with redirect_stdout(StringIO()) as config_output:
             np.__config__.show()
         config_info = config_output.getvalue()
-        
-        if 'mkl' in str(config_info).lower():
-            info['numpy_blas'] = 'Intel MKL'
-        elif 'openblas' in str(config_info).lower():
-            info['numpy_blas'] = 'OpenBLAS'
-        elif 'atlas' in str(config_info).lower():
-            info['numpy_blas'] = 'ATLAS'
+
+        if "mkl" in str(config_info).lower():
+            info["numpy_blas"] = "Intel MKL"
+        elif "openblas" in str(config_info).lower():
+            info["numpy_blas"] = "OpenBLAS"
+        elif "atlas" in str(config_info).lower():
+            info["numpy_blas"] = "ATLAS"
         else:
-            info['numpy_blas'] = 'Standard'
+            info["numpy_blas"] = "Standard"
     except:
-        info['numpy_blas'] = 'Unknown'
-    
+        info["numpy_blas"] = "Unknown"
+
     return info
+
+
+def get_threadpool_summary():
+    """Return a short description of active thread pools."""
+    try:
+        pools = threadpool_info()
+        return ", ".join(f"{p.get('prefix', '')}{p.get('internal_api')}={p.get('num_threads')}" for p in pools) or "none"
+    except Exception:
+        return "unavailable"
 
 
 def print_optimization_status():
     """Print current optimization status."""
     info = get_optimization_info()
-    
+
     print("🔧 Optimization Status:")
     print(f"   Parallel Available: {info['parallel_available']}")
     print(f"   CPU Cores: {info['cpu_count']}")
     print(f"   NumPy BLAS: {info['numpy_blas']}")
+    print(f"   Thread pools: {get_threadpool_summary()}")
 
-    if info['parallel_available']:
+    if info["parallel_available"]:
         print("   ⚡ High performance mode (vectorized)")
     else:
         print("   📊 Standard performance mode")

--- a/spod.py
+++ b/spod.py
@@ -758,8 +758,9 @@ if __name__ == "__main__":
     parser.add_argument("--plot", action="store_true", help="Generate default plots")
     args = parser.parse_args()
 
-    threads_available = get_num_threads()
-    print(f"Available CPU threads detected: {threads_available}")
+    from parallel_utils import get_threadpool_summary
+
+    print(f"Thread pools: {get_threadpool_summary()}")
 
     print_optimization_status()
 

--- a/utils.py
+++ b/utils.py
@@ -24,6 +24,7 @@ try:
         PARALLEL_AVAILABLE,
         blocksfft_optimized,
         calculate_polar_weights_optimized,
+        get_threadpool_summary,
         spod_single_frequency_optimized,
     )
 except Exception:
@@ -524,7 +525,8 @@ class BaseAnalyzer:
         if "q" not in self.data:
             raise ValueError("Data not loaded. Call load_and_preprocess() first.")
 
-        print(f"Computing FFT with {self.nblocks} blocks using {self.n_threads} threads on {FFT_BACKEND} backend...")
+        pools = get_threadpool_summary()
+        print(f"Computing FFT with {self.nblocks} blocks on {FFT_BACKEND} backend [pools: {pools}]")
         self.qhat = blocksfft(
             self.data["q"],
             self.nfft,


### PR DESCRIPTION
## Summary
- show active thread pools via `threadpoolctl`
- report threadpool info when running BSMD/SPOD scripts
- print threadpool summary during FFT block computation
- clarify in README that only BLAS/LAPACK calls honor `OMP_NUM_THREADS`

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e5278f44832c85de3ddd537c15aa