### PR TITLE
Add parallel npz loader

### DIFF
--- a/data_interface.py
+++ b/data_interface.py
@@ -344,8 +344,11 @@ class DNamiXNPZLoader(DataLoader):
         available_fields = None
         Nx = Ny = None
 
-        for f in files:
-            npz = np.load(f)
+        from utils import get_num_threads, parallel_map
+
+        npz_list = parallel_map(np.load, files, threads=get_num_threads())
+
+        for npz, f in zip(npz_list, files):
             if x is None:
                 x = npz["x"]
                 y = npz["y"]

--- a/tests/test_dnami_loader.py
+++ b/tests/test_dnami_loader.py
@@ -1,0 +1,26 @@
+import numpy as np
+from data_interface import DNamiXNPZLoader
+
+
+def test_parallel_loading_identical(tmp_path, monkeypatch):
+    x = np.array([0.0, 1.0])
+    y = np.array([0.0, 1.0])
+    dt = 1.0
+    for i in range(3):
+        arr = np.full((2, 2, 2), i + 1.0)
+        times = np.array([0.0, 1.0]) + 2 * i
+        np.savez(tmp_path / f'file_{i}.npz', x=x, y=y, dt=dt, times=times, u=arr)
+
+    loader = DNamiXNPZLoader()
+
+    monkeypatch.setenv('OMP_NUM_THREADS', '1')
+    data_seq = loader.load(str(tmp_path / 'file_0.npz'))
+
+    monkeypatch.setenv('OMP_NUM_THREADS', '4')
+    data_par = loader.load(str(tmp_path / 'file_0.npz'))
+
+    assert np.array_equal(data_seq['q'], data_par['q'])
+    assert np.array_equal(data_seq['x'], data_par['x'])
+    assert np.array_equal(data_seq['y'], data_par['y'])
+    assert data_seq['dt'] == data_par['dt']
+    assert data_seq['metadata']['loaded_files'] == data_par['metadata']['loaded_files']

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ All imports are centralized here to keep the code clean and consistent.
 import glob
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import h5py
 import numpy as np


### PR DESCRIPTION
## Summary
- parallelize DNamiXNPZLoader using `parallel_map`
- expose `ThreadPoolExecutor` in utils
- test that parallel and sequential loading match

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e524a094832cbef35762de5201c0