### PR TITLE
Improve POD plotting and BSMD shapes

### DIFF
--- a/bmsd.py
+++ b/bmsd.py
@@ -587,8 +587,8 @@ class BSMDAnalyzer(BaseAnalyzer):
         )
 
         for idx in triad_indices:
-            mode1 = self.modes1[idx, :].real.reshape(nx, ny).T
-            mode2 = self.modes2[idx, :].real.reshape(nx, ny).T
+            mode1 = self.modes1[idx, :].real.reshape(ny, nx)
+            mode2 = self.modes2[idx, :].real.reshape(ny, nx)
             triad = self.triads[idx]
 
             if x_coords.ndim == 1 and y_coords.ndim == 1:

--- a/pod.py
+++ b/pod.py
@@ -754,6 +754,19 @@ class PODAnalyzer(BaseAnalyzer):
             plt.ylabel("PSD")
             plt.title(f"Periodogram Mode {i + 1}")
             plt.grid(True, linestyle=":")
+            plt.xlim(1e-2, self.fs / 2)
+            plt.ylim(1e-6, None)
+            peak_idx = int(np.argmax(psd))
+            peak_freq = freqs[peak_idx]
+            plt.axvline(peak_freq, color="r", linestyle="--", linewidth=1)
+            plt.text(
+                peak_freq,
+                psd[peak_idx],
+                f"{peak_freq:.3f}",
+                color="r",
+                ha="right",
+                va="bottom",
+            )
 
         plt.tight_layout()
         plot_filename = os.path.join(self.figures_dir, f"{self.data_root}_pod_time_coeffs.png")


### PR DESCRIPTION
## Summary
- show axis limits and annotate peak frequency in POD periodogram plots
- fix BSMD mode reshaping to match spatial grids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f1e6216c832c8d54c51fbb52772f