### PR TITLE
Remove Strouhal number from SPOD figure names

### DIFF
--- a/spod.py
+++ b/spod.py
@@ -621,16 +621,16 @@ class SPODAnalyzer(BaseAnalyzer):
                 if modes_per_fig == 1 and ncols == 1:
                     fname = os.path.join(
                         self.figures_dir,
-                        f"{self.data_root}_SPOD_mode{start + 1}_St{st_val:.4f}_{var_name}.png",
+                        f"{self.data_root}_SPOD_mode{start + 1}_freq{f_idx}_{var_name}.png",
                     )
                 else:
                     fname = os.path.join(
                         self.figures_dir,
-                        f"{self.data_root}_SPOD_modes_{start + 1}_to_{end}_St{st_val:.4f}_{var_name}.png",
+                        f"{self.data_root}_SPOD_modes_{start + 1}_to_{end}_freq{f_idx}_{var_name}.png",
                     )
                 fig.savefig(fname, dpi=FIG_DPI)
                 plt.close(fig)
-                print(f"SPOD modes {start + 1}-{end} at St={st_val:.4f} saved to {fname}")
+                print(f"SPOD modes {start + 1}-{end} at St={st_val:.4f} (freq index {f_idx}) saved to {fname}")
 
     def plot_cumulative_energy(self, freq_idx=None):
         """Plot cumulative energy captured by modes at a given frequency."""
@@ -649,7 +649,7 @@ class SPODAnalyzer(BaseAnalyzer):
         ax.set_title(f"Cumulative energy at St={self.St[freq_idx]:.3f}")
         plot_filename = os.path.join(
             self.figures_dir,
-            f"{self.data_root}_SPOD_cumulative_St{self.St[freq_idx]:.3f}.{FIG_FORMAT}",
+            f"{self.data_root}_SPOD_cumulative_freq{freq_idx}.{FIG_FORMAT}",
         )
         plt.savefig(plot_filename, dpi=FIG_DPI)
         plt.close(fig)
@@ -680,7 +680,7 @@ class SPODAnalyzer(BaseAnalyzer):
         ax.set_title(f"SPOD Time Coefficients at St={self.St[freq_idx]:.4f}")
         plot_filename = os.path.join(
             self.figures_dir,
-            f"{self.data_root}_SPOD_timecoeffs_St{self.St[freq_idx]:.4f}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
+            f"{self.data_root}_SPOD_timecoeffs_freq{freq_idx}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
         )
         plt.savefig(plot_filename, dpi=FIG_DPI)
         plt.close(fig)
@@ -720,7 +720,7 @@ class SPODAnalyzer(BaseAnalyzer):
         ax.set_title(f"Reconstruction Error at St={self.St[freq_idx]:.4f}")
         plot_filename = os.path.join(
             self.figures_dir,
-            f"{self.data_root}_SPOD_reconstruction_error_St{self.St[freq_idx]:.4f}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
+            f"{self.data_root}_SPOD_reconstruction_error_freq{freq_idx}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
         )
         plt.savefig(plot_filename, dpi=FIG_DPI)
         plt.close(fig)
@@ -745,7 +745,7 @@ class SPODAnalyzer(BaseAnalyzer):
         ax.legend()
         plot_filename = os.path.join(
             self.figures_dir,
-            f"{self.data_root}_SPOD_complex_St{self.St[freq_idx]:.4f}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
+            f"{self.data_root}_SPOD_complex_freq{freq_idx}_nfft{self.nfft}_noverlap{self.overlap}.{FIG_FORMAT}",
         )
         plt.savefig(plot_filename, dpi=FIG_DPI)
         plt.close(fig)

--- a/tests/test_spod_plot.py
+++ b/tests/test_spod_plot.py
@@ -53,11 +53,13 @@ def test_plot_modes_and_timecoeffs(tmp_path):
     analyzer.compute_fft_blocks()
     analyzer.perform_spod()
     analyzer.plot_modes(plot_n_modes=1)
-    st = analyzer.St[np.argmax(analyzer.eigenvalues[:, 0])]
-    expected_modes = tmp_path / f"dummy_SPOD_mode1_St{st:.4f}_q.png"
+    freq_idx = int(np.argmax(analyzer.eigenvalues[:, 0]))
+    expected_modes = tmp_path / f"dummy_SPOD_mode1_freq{freq_idx}_q.png"
     assert expected_modes.exists()
     analyzer.plot_time_coeffs()
-    expected_time = tmp_path / f"dummy_SPOD_timecoeffs_St{st:.4f}_nfft4_noverlap0.0.png"
+    expected_time = tmp_path / (
+        f"dummy_SPOD_timecoeffs_freq{freq_idx}_nfft4_noverlap0.0.png"
+    )
     assert expected_time.exists()
 
 
@@ -84,6 +86,8 @@ def test_plot_reconstruction_error(tmp_path):
     analyzer.compute_fft_blocks()
     analyzer.perform_spod()
     analyzer.plot_reconstruction_error()
-    st = analyzer.St[np.argmax(analyzer.eigenvalues[:, 0])]
-    expected = tmp_path / f"dummy_SPOD_reconstruction_error_St{st:.4f}_nfft4_noverlap0.0.png"
+    freq_idx = int(np.argmax(analyzer.eigenvalues[:, 0]))
+    expected = tmp_path / (
+        f"dummy_SPOD_reconstruction_error_freq{freq_idx}_nfft4_noverlap0.0.png"
+    )
     assert expected.exists()


### PR DESCRIPTION
## Summary
- avoid very large `St` values in filenames by using the frequency index instead
- update SPOD plotting tests accordingly

## Testing
- `pytest`
- `python pyModal.py --spod` *(fails: Unable to allocate 12.4 GiB array)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4d69038832caf16eee7a84979a9