### PR TITLE
Add per-component weight support for SPOD

### DIFF
--- a/spod.py
+++ b/spod.py
@@ -267,7 +267,7 @@ class SPODAnalyzer(BaseAnalyzer):
     ############################################################
     # Core SPOD Computation                                    #
     ############################################################
-    def perform_spod(self):
+    def perform_spod(self, weights=None):
         """
         Performs the core SPOD analysis (eigenvalue decomposition for each frequency).
 
@@ -308,13 +308,14 @@ class SPODAnalyzer(BaseAnalyzer):
 
         print("Performing SPOD for each frequency...")
 
+        weights = weights if weights is not None else self.W
         for i in tqdm(range(num_freq_bins), desc="SPOD Computation", unit="freq"):
             qhat_freq = self.qhat[i, :, :]
             phi_freq, lambda_freq, psi_freq = spod_function(
                 qhat_freq,
                 self.nblocks,
                 self.dst,
-                self.W,
+                weights,
                 return_psi=True,
                 use_parallel=self.use_parallel,
             )

--- a/tests/test_spod_function.py
+++ b/tests/test_spod_function.py
@@ -11,3 +11,15 @@ def test_spod_function_simple():
     assert np.allclose(lam, 1.0)
     assert np.allclose(phi[:, 0], [1.0, 0.0])
 
+
+def test_spod_function_per_component_weights():
+    qhat = np.array([[1.0], [2.0]], dtype=complex)
+    w = np.zeros((1, 1, 2))
+    w[0, 0, 0] = 1.0
+    w[0, 0, 1] = 2.0
+    phi, lam, psi = spod_function(qhat, nblocks=1, dst=1.0, w=w, return_psi=True)
+    assert phi.shape == (2, 1)
+    assert psi.shape == (1, 1)
+    assert np.allclose(lam, 9.0)
+    assert np.allclose(phi[:, 0], [1 / 3, 2 / 3])
+


### PR DESCRIPTION
## Summary
- allow SPODAnalyzer and `spod_function` to handle weight matrices
- provide helper `_flatten_weights` for vectorising weight arrays
- update unit tests for new behaviour

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857eebb669c832c89c55349a097a400