### PR TITLE
Fix repeated POD output and update sample data paths

### DIFF
--- a/bmsd.py
+++ b/bmsd.py
@@ -755,7 +755,7 @@ if __name__ == "__main__":
 
     print_optimization_status()
 
-    data_file = "./data/consolidated_data.npz"
+    data_file = "./data/snp1-947_u.npz"
 
     if DNamiXNPZLoader is not None and data_file.endswith(".npz"):
         loader = DNamiXNPZLoader()

--- a/dmd.py
+++ b/dmd.py
@@ -578,7 +578,7 @@ if __name__ == "__main__":
         load_config(args.config)
 
     # Example: data_file = "./data/consolidated_data.npz"
-    data_file = "./data/consolidated_data.npz"
+    data_file = "./data/snp1-947_u.npz"
     n_modes_to_save_main = 8
     n_modes_to_plot_spatial_main = 8
     n_coeffs_to_plot_time_main = 8

--- a/pod.py
+++ b/pod.py
@@ -1133,8 +1133,7 @@ class PODAnalyzer(BaseAnalyzer):
         # Perform POD
         self.perform_pod()
 
-        # Identify correlated mode pairs before plotting
-        list(self.check_mode_pair_phase())
+        # Identify correlated mode pairs only when plotting
 
         # Save results
         self.save_results()  # This already calls super().save_results()
@@ -1223,10 +1222,8 @@ if __name__ == "__main__":
                 plot_n_modes_spatial=n_modes_to_plot_spatial_main,
                 plot_n_coeffs_time=n_coeffs_to_plot_time_main,
             )
-        if args.plot:
-            # Only load results if we haven't already computed them
-            if not args.compute:
-                analyzer.load_results()
+        elif args.plot:
+            analyzer.load_results()
             analyzer.plot_eigenvalues()
             analyzer.plot_modes_pair_detailed(plot_n_modes=n_modes_to_plot_spatial_main)
             analyzer.plot_modes_grid(energy_threshold=99.7)
@@ -1234,4 +1231,3 @@ if __name__ == "__main__":
             analyzer.plot_cumulative_energy()
             analyzer.plot_reconstruction_error()
             analyzer.plot_reconstruction_comparison()
-        print_summary("POD", analyzer.results_dir, analyzer.figures_dir)

--- a/spod.py
+++ b/spod.py
@@ -778,7 +778,7 @@ if __name__ == "__main__":
     # data_file = "./data/jetLES_small.mat"  # Updated data path
     # data_file = "./data/jetLES.mat"  # Path to your data file
     # data_file = "./data/cavityPIV.mat"  # Path to your data file
-    data_file = "./data/consolidated_data.npz"
+    data_file = "./data/snp1-947_u.npz"
 
     # Default parameters
     nfft_param = 128  # FFT block size


### PR DESCRIPTION
## Summary
- avoid duplicated POD output by removing redundant plotting section
- use existing `snp1-947_u.npz` sample in DMD, SPOD and BSMD
- tweak command flow in POD CLI so plots aren't drawn twice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585121af20832ca64002ca67537b80