### PR TITLE
Improve dt handling and add Strouhal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ pyModal is the only open-source package to combine POD + SPOD and BSMD in a sing
 - **Proper Orthogonal Decomposition (POD)**
   Performs a weighted singular value decomposition of mean-subtracted snapshots
   to recover energy-ranked spatial modes and their temporal coefficients.
+  Periodograms of the time coefficients are plotted in Hertz using the
+  sampling interval `dt`. Multiply the frequency axis by `L/U` to express
+  results in the dimensionless Strouhal number when physical scales are known.
 
 - **Spectral Proper Orthogonal Decomposition (SPOD)**
   Solves the cross-spectral density eigenvalue problem to yield energy-ranked,

--- a/data_interface.py
+++ b/data_interface.py
@@ -340,7 +340,6 @@ class DNamiXNPZLoader(DataLoader):
         q_list = []
         times_list = []
         x = y = None
-        dt = None
         available_fields = None
         Nx = Ny = None
 
@@ -356,9 +355,7 @@ class DNamiXNPZLoader(DataLoader):
                     x = x[:, 0]
                 if y.ndim == 2:
                     y = y[0, :]
-            if dt is None and "dt" in npz:
-                dt_val = npz["dt"]
-                dt = float(np.mean(dt_val)) if dt_val.size > 0 else None
+            # Ignore stored 'dt' field; compute from times instead
             if available_fields is None:
                 available_fields = [k for k in ("u", "v", "p") if k in npz]
             if field is None:
@@ -378,13 +375,13 @@ class DNamiXNPZLoader(DataLoader):
         q = np.concatenate(q_list, axis=0)
         times = np.concatenate(times_list)
         Ns = times.shape[0]
-        if dt is None:
-            if len(times) > 1:
-                diffs = np.diff(times)
-                diffs = diffs[np.nonzero(diffs)]
-                dt = float(np.mean(diffs)) if diffs.size > 0 else 1.0
-            else:
-                dt = 1.0
+        if len(times) > 1:
+            diffs = np.diff(times)
+            diffs = diffs[np.nonzero(diffs)]
+            dt_from_times = float(np.mean(diffs)) if diffs.size > 0 else 1.0
+        else:
+            dt_from_times = 1.0
+        dt = dt_from_times
         print(f"   Processed shape: q={q.shape}, Nx={Nx}, Ny={Ny}, Ns={Ns}, dt={dt}, field={field}")
         return {
             "q": q,

--- a/pod.py
+++ b/pod.py
@@ -703,7 +703,7 @@ class PODAnalyzer(BaseAnalyzer):
         plt.close(fig)
         print(f"Saving figure {plot_filename}")
 
-    def plot_time_coefficients(self, n_coeffs_to_plot=2, n_snapshots_plot=None):
+    def plot_time_coefficients(self, n_coeffs_to_plot=2, n_snapshots_plot=None, L=None, U=None):
         """Plot the temporal coefficients for selected modes.
 
         Displays the time evolution of the coefficients for the first `n_coeffs_to_plot` modes.
@@ -713,9 +713,11 @@ class PODAnalyzer(BaseAnalyzer):
 
         Args:
             n_coeffs_to_plot (int, optional): Number of leading temporal coefficients to plot.
-                                            Defaults to 2.
+                Defaults to 2.
             n_snapshots_plot (int, optional): Number of time snapshots to include in the plot.
-                                              If None, all snapshots are used. Defaults to None.
+                If None, all snapshots are used. Defaults to None.
+            L (float, optional): Characteristic length scale for Strouhal conversion.
+            U (float, optional): Characteristic velocity for Strouhal conversion.
         """
         if self.time_coefficients.size == 0:
             print("No time coefficients to plot. Run perform_pod() first.")
@@ -749,11 +751,16 @@ class PODAnalyzer(BaseAnalyzer):
 
             plt.subplot(n_coeffs_to_plot, 2, 2 * i + 2)
             freqs, psd = signal.periodogram(coeff, self.fs, scaling="density")
+            if L is not None and U is not None:
+                freqs = freqs * L / U
+                xlabel = "Strouhal Number (St)"
+            else:
+                xlabel = "Frequency"
             plt.semilogy(freqs, psd)
             plt.xscale("log")
             plt.xlim(1e-1, 1e4)
             plt.ylim(1e-6, None)
-            plt.xlabel("Frequency")
+            plt.xlabel(xlabel)
             plt.ylabel("PSD")
             plt.title(f"Periodogram Mode {i + 1}")
             plt.grid(True, linestyle=":")

--- a/tests/test_dnami_loader.py
+++ b/tests/test_dnami_loader.py
@@ -24,3 +24,15 @@ def test_parallel_loading_identical(tmp_path, monkeypatch):
     assert np.array_equal(data_seq['y'], data_par['y'])
     assert data_seq['dt'] == data_par['dt']
     assert data_seq['metadata']['loaded_files'] == data_par['metadata']['loaded_files']
+
+
+def test_dt_from_times(tmp_path):
+    x = np.array([0.0, 1.0])
+    y = np.array([0.0, 1.0])
+    arr = np.ones((2, 2, 2))
+    np.savez(tmp_path / 'file.npz', x=x, y=y, dt=0.01, times=np.array([0.0, 1.0]), u=arr)
+
+    loader = DNamiXNPZLoader()
+    data = loader.load(str(tmp_path / 'file.npz'), load_single=True)
+
+    assert data['dt'] == 1.0

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -1,4 +1,5 @@
 import numpy as np
+import matplotlib.pyplot as plt
 from pod import PODAnalyzer
 
 
@@ -23,4 +24,34 @@ def test_perform_pod_simple():
     assert analyzer.modes.shape == (2, 2)
     assert analyzer.time_coefficients.shape == (3, 2)
     assert np.isclose(analyzer.eigenvalues[0], 5.333333333333333, atol=1e-6)
+
+
+def test_periodogram_strouhal_axis(monkeypatch, tmp_path):
+    data = {
+        'q': np.random.randn(4, 2),
+        'x': np.array([0.0, 1.0]),
+        'y': np.array([0.0]),
+        'dt': 1.0,
+        'Nx': 2,
+        'Ny': 1,
+        'Ns': 4,
+    }
+    analyzer = PODAnalyzer(
+        file_path='dummy',
+        data_loader=lambda _: data,
+        figures_dir=tmp_path,
+        spatial_weight_type='uniform',
+        n_modes_save=1,
+    )
+    analyzer.load_and_preprocess()
+    analyzer.perform_pod()
+
+    saved = {}
+    monkeypatch.setattr(plt, 'savefig', lambda fname, dpi=None: saved.setdefault('fig', plt.gcf()))
+    monkeypatch.setattr(plt, 'close', lambda fig=None: None)
+
+    analyzer.plot_time_coefficients(n_coeffs_to_plot=1, L=1.0, U=2.0)
+    fig = saved['fig']
+    ax = fig.axes[1]
+    assert ax.get_xlabel() == 'Strouhal Number (St)'
 


### PR DESCRIPTION
## Summary
- compute `dt` from time array in `DNamiXNPZLoader`
- add `L` and `U` parameters for Strouhal numbers in POD periodograms
- document frequency units in the README
- test new loader behaviour and plotting option

## Testing
- `python indent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587853ba58832cb822e9b5c694c110